### PR TITLE
Add new screen layout

### DIFF
--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -28,7 +28,7 @@
     .backdrop {
         position: fixed;
         inset: 0;
-        background: rgba(0, 0, 0, 0.4);
+        background: rgba(0, 0, 0, 0.5);
         backdrop-filter: blur(4px);
         z-index: 50;
     }
@@ -42,12 +42,12 @@
         max-width: 280px;
         width: min(280px, 88vw);
         max-height: 240px;
-        background: var(--surface-soft);
+        background: color-mix(in srgb, var(--surface-soft) 92%, #fefaf2);
         color: var(--text);
-        border: 1px solid var(--outline-soft);
+        border: 1px solid color-mix(in srgb, var(--outline-soft) 70%, #d8c9a5);
         border-radius: 12px;
         padding: 0.75rem 0.9rem;
-        box-shadow: 0 10px 20px var(--shadow-soft);
+        box-shadow: 0 14px 28px color-mix(in srgb, rgba(0, 0, 0, 0.45) 80%, transparent);
         z-index: 51;
         display: grid;
         gap: 0.45rem;

--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+    export let open = false;
+    export let title = "";
+    export let body = "";
+    export let confirmLabel = "Confirm";
+    export let cancelLabel = "Cancel";
+    export let onConfirm: () => void;
+    export let onCancel: () => void;
+</script>
+
+{#if open}
+    <div class="backdrop" role="presentation" on:click={onCancel}></div>
+    <div class="dialog" role="alertdialog" aria-modal="true" aria-label={title}>
+        {#if title}<h3>{title}</h3>{/if}
+        {#if body}<p>{body}</p>{/if}
+        <div class="actions">
+            <button class="ghost" type="button" on:click={onCancel}>
+                {cancelLabel}
+            </button>
+            <button class="primary" type="button" on:click={onConfirm}>
+                {confirmLabel}
+            </button>
+        </div>
+    </div>
+{/if}
+
+<style>
+    .backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.4);
+        backdrop-filter: blur(4px);
+        z-index: 50;
+    }
+
+    .dialog {
+        position: fixed;
+        top: 20%;
+        left: 0;
+        right: 0;
+        margin: 0 auto;
+        max-width: 280px;
+        width: min(280px, 88vw);
+        max-height: 240px;
+        background: var(--surface-soft);
+        color: var(--text);
+        border: 1px solid var(--outline-soft);
+        border-radius: 12px;
+        padding: 0.75rem 0.9rem;
+        box-shadow: 0 10px 20px var(--shadow-soft);
+        z-index: 51;
+        display: grid;
+        gap: 0.45rem;
+        text-align: center;
+        overflow: hidden;
+    }
+
+    h3 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text);
+    }
+
+    p {
+        margin: 0;
+        color: var(--text-subtle);
+        line-height: 1.3;
+        font-size: 0.9rem;
+    }
+
+    .actions {
+        display: flex;
+        justify-content: center;
+        gap: 0.45rem;
+        margin-top: 0.25rem;
+    }
+
+    .actions .ghost {
+        border: 1px solid var(--outline-strong);
+        background: transparent;
+        color: var(--text);
+        border-radius: 10px;
+        padding: 0.45rem 0.85rem;
+        cursor: pointer;
+        text-transform: capitalize;
+    }
+
+    .actions .primary {
+        border: none;
+        border-radius: 10px;
+        padding: 0.45rem 0.95rem;
+        font-weight: 800;
+        cursor: pointer;
+        background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+        color: var(--ink-strong);
+        box-shadow: 0 8px 16px var(--shadow-soft);
+        text-transform: capitalize;
+    }
+
+    .actions button:hover {
+        transform: translateY(-1px);
+    }
+</style>

--- a/src/lib/components/Hero/Hero.svelte
+++ b/src/lib/components/Hero/Hero.svelte
@@ -5,9 +5,10 @@
     export let progressLabel: string;
     export let progressStage: string;
     export let progressPercent: number;
+    export let theme: "light" | "dark" = "dark";
 </script>
 
-<header class="hero">
+<header class={`hero ${theme === "light" ? "light" : "dark"}`}>
     <div class="hero-text">
         <p class="eyebrow">{eyebrow}</p>
         <h1>{title}</h1>
@@ -39,6 +40,12 @@
         border-radius: 18px;
         background: linear-gradient(135deg, var(--panel-veil-1), var(--panel-veil-2));
         box-shadow: 0 18px 40px var(--shadow-soft);
+    }
+
+    .hero.light {
+        background:
+            linear-gradient(135deg, rgba(248, 243, 231, 0.92), rgba(229, 212, 185, 0.88)),
+            linear-gradient(135deg, var(--panel-veil-1), var(--panel-veil-2));
     }
 
     .hero-text h1 {

--- a/src/lib/components/Hero/Hero.svelte
+++ b/src/lib/components/Hero/Hero.svelte
@@ -20,7 +20,10 @@
                 <span class="progress-stage">{progressStage}</span>
             </div>
             <div class="progress-track">
-                <div class="progress-fill" style={`width: ${progressPercent}%`}></div>
+                <div
+                    class="progress-fill"
+                    style={`width: ${progressPercent}%`}
+                ></div>
             </div>
         </div>
     </div>
@@ -38,13 +41,20 @@
         padding: 1.5rem;
         border: 1px solid var(--outline-soft);
         border-radius: 18px;
-        background: linear-gradient(135deg, var(--panel-veil-1), var(--panel-veil-2));
+        background: linear-gradient(
+            135deg,
+            var(--panel-veil-1),
+            var(--panel-veil-2)
+        );
         box-shadow: 0 18px 40px var(--shadow-soft);
     }
 
     .hero.light {
-        background:
-            linear-gradient(135deg, rgba(248, 243, 231, 0.92), rgba(229, 212, 185, 0.88)),
+        background: linear-gradient(
+                135deg,
+                rgba(248, 243, 231, 0.92),
+                rgba(229, 212, 185, 0.88)
+            ),
             linear-gradient(135deg, var(--panel-veil-1), var(--panel-veil-2));
     }
 

--- a/src/lib/components/Menu/MenuPanel.svelte
+++ b/src/lib/components/Menu/MenuPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { fade } from "svelte/transition";
     import LanguageSwitcher from "./LanguageSwitcher.svelte";
     import ThemeToggle from "./ThemeToggle.svelte";
     import type { Locale } from "$lib/types";
@@ -20,6 +21,24 @@
     export let locale: Locale;
     export let flags: Record<Locale, string> = { en: "🇬🇧", es: "🇪🇸", pt: "🇧🇷" };
     export let selectLanguage: (id: Locale) => void;
+
+    let closeTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const closeMenu = () => {
+        if (menuOpen) toggleMenu();
+    };
+
+    const scheduleClose = () => {
+        if (closeTimer) clearTimeout(closeTimer);
+        closeTimer = setTimeout(() => closeMenu(), 160);
+    };
+
+    const cancelClose = () => {
+        if (closeTimer) {
+            clearTimeout(closeTimer);
+            closeTimer = null;
+        }
+    };
 </script>
 
 <div class="hero-panel">
@@ -43,7 +62,13 @@
                 </span>
             </button>
             {#if menuOpen}
-                <div class="menu-dropdown" id="user-menu">
+                <div
+                    class="menu-dropdown"
+                    id="user-menu"
+                    on:mouseleave={scheduleClose}
+                    on:mouseenter={cancelClose}
+                    transition:fade={{ duration: 140 }}
+                >
                     <div class="menu-section">
                         <div class="menu-label">{accountLabel}</div>
                         <button class="menu-item">{loginLabel}</button>

--- a/src/lib/components/Question/QuestionCard.svelte
+++ b/src/lib/components/Question/QuestionCard.svelte
@@ -9,11 +9,13 @@
     export let selected: string | null;
     export let revealed: boolean;
     export let completed: boolean;
+    export let retakeDisabled: boolean = false;
     export let theme: "light" | "dark";
     export let t: (key: string) => string;
     export let answeredCorrectly: boolean;
     export let onSelect: (id: string) => void;
     export let onNext: () => void;
+    export let onRetake: () => void;
     export let onRestart: () => void;
     export let isLastQuestion: boolean;
     export let timeLeft: number;
@@ -166,16 +168,17 @@
                 >
                     <span class="bullet">{option.id.toUpperCase()}</span>
                     <span class="text">{option.text[locale]}</span>
-                    <span
-                        class={`badge ${revealed ? "" : "placeholder"}`}
-                        class:correct-badge={revealed && option.correct}
-                    >
-                        {#if revealed}
-                            {option.correct ? t("correct") : " "}
-                        {:else}
-                            {t("correct")}
-                        {/if}
-                    </span>
+                    {#if revealed && selected === option.id && option.correct}
+                        <span class="badge correct-badge" aria-label={t("correct")}>
+                            ✓
+                        </span>
+                    {:else if revealed && selected === option.id && !option.correct}
+                        <span class="badge incorrect-badge" aria-label={t("incorrect")}>
+                            ✕
+                        </span>
+                    {:else}
+                        <span class="badge placeholder"></span>
+                    {/if}
                 </button>
             {/each}
         </div>
@@ -211,7 +214,9 @@
 
     <div class="actions">
         {#if !completed}
-            <button class="ghost" on:click={onRestart}>{t("restart")}</button>
+            <button class="ghost" on:click={onRetake} disabled={retakeDisabled}
+                >Retake</button
+            >
             <button class="primary" disabled={!revealed} on:click={onNext}>
                 {isLastQuestion ? t("finish") : t("next")}
             </button>
@@ -494,6 +499,15 @@
     .badge.correct-badge {
         color: var(--success);
         background: transparent;
+        font-size: 1.3rem;
+        font-weight: 900;
+    }
+
+    .badge.incorrect-badge {
+        color: var(--danger);
+        background: transparent;
+        font-size: 1.3rem;
+        font-weight: 900;
     }
 
     .explanation {

--- a/src/lib/components/Question/QuestionCard.svelte
+++ b/src/lib/components/Question/QuestionCard.svelte
@@ -9,6 +9,7 @@
     export let selected: string | null;
     export let revealed: boolean;
     export let completed: boolean;
+    export let theme: "light" | "dark";
     export let t: (key: string) => string;
     export let answeredCorrectly: boolean;
     export let onSelect: (id: string) => void;
@@ -20,6 +21,17 @@
     export let pauseTimer: () => void;
     export let resumeTimer: () => void;
     export let onHome: () => void;
+
+    const lightBackground =
+        question.image_url_light ??
+        (question.image_url?.includes("quest-hero")
+            ? "/illustrations/quest-hero-light.svg"
+            : question.image_url);
+
+    const darkBackground =
+        question.image_url_dark ??
+        question.image_url ??
+        "/illustrations/quest-hero.svg";
 
     const openShare = async () => {
         const url = window?.location?.href ?? "/";
@@ -44,21 +56,32 @@
     };
 </script>
 
-<section class="card">
-    <div class="hero-image">
-        <img
-            src={question.image_url ?? "/illustrations/quest-hero.svg"}
-            alt={question.stage[locale]}
-            loading="lazy"
-        />
-    </div>
+<section
+    class={`card ${theme === "light" ? "light-mode" : "dark-mode"}`}
+    style={`--card-img: url('${
+        theme === "light"
+            ? (lightBackground ?? "/illustrations/quest-hero-light.svg")
+            : darkBackground
+    }');`}
+>
     <div class="meta">
         <div class="meta-left">
             <span class="pill">{question.stage[locale]}</span>
-            <span class="sub">{t("question")} {currentIndex + 1} {t("of")} {totalQuestions}</span>
+            <span class="sub"
+                >{t("question")}
+                {currentIndex + 1}
+                {t("of")}
+                {totalQuestions}</span
+            >
         </div>
         <div class="meta-actions">
-            <button class="icon-link" type="button" on:click={onHome} aria-label="Home" title="Home">
+            <button
+                class="icon-link"
+                type="button"
+                on:click={onHome}
+                aria-label="Home"
+                title="Home"
+            >
                 <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                     <path
                         d="M4 10.5 12 4l8 6.5V20a1 1 0 0 1-1 1h-5v-5H10v5H5a1 1 0 0 1-1-1z"
@@ -69,7 +92,13 @@
                     />
                 </svg>
             </button>
-            <button class="icon-link" type="button" on:click={openShare} aria-label="Share" title="Share">
+            <button
+                class="icon-link"
+                type="button"
+                on:click={openShare}
+                aria-label="Share"
+                title="Share"
+            >
                 <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                     <path
                         d="M6 14.5v4a1.5 1.5 0 0 0 1.5 1.5h9A1.5 1.5 0 0 0 18 18.5v-4"
@@ -122,43 +151,63 @@
         <p class="source">{t("source")}: {question.source}</p>
     {/if}
 
-    <div class="options">
-        {#each question.options as option}
-            <button
-                class:selected={selected === option.id}
-                class:correct={revealed && option.correct && selected === option.id}
-                class:incorrect={revealed && selected === option.id && !option.correct}
-                on:click={() => onSelect(option.id)}
-            >
-                <span class="bullet">{option.id.toUpperCase()}</span>
-                <span class="text">{option.text[locale]}</span>
-                {#if revealed}
-                    <span class="badge">{option.correct ? t("correct") : " "}</span>
-                {/if}
-            </button>
-        {/each}
-    </div>
-
-    {#if revealed}
-        <div class="explanation">
-            <p class:correct={answeredCorrectly} class:incorrect={!answeredCorrectly}>
-                {#if answeredCorrectly}
-                    {t("correctMsg")} {question.options.find((o) => o.id === selected)?.explanation[locale]}
-                {:else}
-                    {t("incorrectMsg")} {question.options.find((o) => o.id === selected)?.explanation[locale]}
-                {/if}
-            </p>
-            {#if !completed}
-                <div
-                    role="presentation"
-                    on:mouseenter={pauseTimer}
-                    on:mouseleave={resumeTimer}
+    <div class="interactive">
+        <div class="options">
+            {#each question.options as option}
+                <button
+                    class:selected={selected === option.id}
+                    class:correct={revealed &&
+                        option.correct &&
+                        selected === option.id}
+                    class:incorrect={revealed &&
+                        selected === option.id &&
+                        !option.correct}
+                    on:click={() => onSelect(option.id)}
                 >
-                    <TimerBar timeLeft={timeLeft} duration={answerDuration} />
-                </div>
+                    <span class="bullet">{option.id.toUpperCase()}</span>
+                    <span class="text">{option.text[locale]}</span>
+                    <span
+                        class={`badge ${revealed ? "" : "placeholder"}`}
+                        class:correct-badge={revealed && option.correct}
+                    >
+                        {#if revealed}
+                            {option.correct ? t("correct") : " "}
+                        {:else}
+                            {t("correct")}
+                        {/if}
+                    </span>
+                </button>
+            {/each}
+        </div>
+
+        <div class={`explanation ${revealed ? "visible" : "placeholder"}`}>
+            {#if revealed}
+                <p
+                    class:correct={answeredCorrectly}
+                    class:incorrect={!answeredCorrectly}
+                >
+                    {#if answeredCorrectly}
+                        {t("correctMsg")}
+                        {question.options.find((o) => o.id === selected)
+                            ?.explanation[locale]}
+                    {:else}
+                        {t("incorrectMsg")}
+                        {question.options.find((o) => o.id === selected)
+                            ?.explanation[locale]}
+                    {/if}
+                </p>
+                {#if !completed}
+                    <div
+                        role="presentation"
+                        on:mouseenter={pauseTimer}
+                        on:mouseleave={resumeTimer}
+                    >
+                        <TimerBar {timeLeft} duration={answerDuration} />
+                    </div>
+                {/if}
             {/if}
         </div>
-    {/if}
+    </div>
 
     <div class="actions">
         {#if !completed}
@@ -167,7 +216,9 @@
                 {isLastQuestion ? t("finish") : t("next")}
             </button>
         {:else}
-            <button class="primary" on:click={onRestart}>{t("playAgain")}</button>
+            <button class="primary" on:click={onRestart}
+                >{t("playAgain")}</button
+            >
         {/if}
     </div>
 </section>
@@ -176,15 +227,49 @@
     .card {
         position: relative;
         z-index: 1;
+        display: flex;
+        flex-direction: column;
         padding: 1.6rem;
         border: 1px solid var(--outline-soft);
         border-radius: 18px;
         background:
-            linear-gradient(160deg, var(--card-veil-1), var(--card-veil-2)),
-            url("/illustrations/question-bg.svg") center/cover,
+            linear-gradient(180deg, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.45)),
+            var(--card-img) center/cover,
             var(--bg);
+        background-size: cover, cover, auto;
+        background-position: center;
+        background-repeat: no-repeat;
         box-shadow: 0 18px 40px var(--shadow-strong);
         overflow: hidden;
+        color: var(--ink-strong);
+        min-height: 720px;
+    }
+
+    .card.dark-mode {
+        color: #d3d7e4;
+        background:
+            linear-gradient(180deg, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0.78)),
+            var(--card-img) center/cover,
+            var(--bg);
+    }
+
+    .card.light-mode {
+        background:
+            linear-gradient(
+                185deg,
+                rgba(246, 236, 210, 0.78),
+                rgba(226, 206, 176, 0.68)
+            ),
+            var(--card-img) center/cover,
+            var(--bg);
+        background-blend-mode: soft-light, normal, normal;
+        color: var(--text);
+    }
+
+    .card.dark-mode h2,
+    .card.dark-mode .source {
+        color: #d3d7e4;
+        text-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
     }
 
     .card::after {
@@ -216,30 +301,17 @@
         align-items: center;
     }
 
-    .hero-image {
-        width: 100%;
-        max-height: 220px;
-        overflow: hidden;
-        border-radius: 14px;
-        border: 1px solid var(--outline-soft);
-        margin-bottom: 0.85rem;
-        background: var(--surface-soft);
-    }
-
-    .hero-image img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        display: block;
-    }
-
     .pill {
         display: inline-flex;
         align-items: center;
         gap: 0.35rem;
         padding: 0.38rem 0.85rem;
         border-radius: 999px;
-        background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+        background: linear-gradient(
+            135deg,
+            var(--accent),
+            var(--accent-strong)
+        );
         color: var(--ink-strong);
         font-weight: 800;
         text-transform: uppercase;
@@ -283,93 +355,163 @@
     h2 {
         margin: 0.3rem 0 0.2rem;
         font-size: 1.35rem;
-        color: var(--text);
+        color: var(--ink-strong);
         line-height: 1.4;
+        text-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
     }
 
     .source {
         margin: 0 0 1rem;
-        color: var(--text-muted);
+        color: var(--ink-strong);
         font-size: 0.95rem;
+        text-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+    }
+
+    .interactive {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        padding-bottom: 0.35rem;
+        justify-content: space-between;
+        position: relative;
     }
 
     .options {
         display: grid;
         gap: 0.75rem;
-        margin: 1.15rem 0 1.35rem;
+        margin: 1.15rem 0 0.25rem;
     }
 
     .options button {
         all: unset;
         cursor: pointer;
         display: grid;
-        grid-template-columns: auto 1fr auto;
+        grid-template-columns: 28px 1fr 64px;
         align-items: center;
-        gap: 0.9rem;
-        padding: 0.95rem 1.05rem;
-        border: 1px solid var(--outline-soft);
-        border-radius: 12px;
-        background: linear-gradient(135deg, var(--surface-strong), var(--surface-soft));
+        gap: 0.5rem;
+        padding: 0.65rem 0.1rem;
+        color: var(--ink-strong);
+        text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+        background: transparent;
+        min-height: 52px;
+        border: none;
+        border-bottom: 1px solid transparent;
         transition:
             transform 120ms ease,
-            border-color 120ms ease,
             background 120ms ease,
-            box-shadow 120ms ease;
+            box-shadow 120ms ease,
+            opacity 120ms ease;
+    }
+
+    .card.light-mode .options button {
+        color: var(--text);
+        text-shadow: none;
+        border-bottom-color: rgba(214, 184, 130, 0.35);
+    }
+
+    .card.dark-mode .options button {
+        color: #c8cede;
+        text-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+        border-bottom-color: rgba(255, 255, 255, 0.12);
     }
 
     .options button:hover {
         transform: translateY(-1px);
-        border-color: var(--accent);
-        box-shadow: 0 12px 24px var(--shadow-soft);
+        border-bottom-color: var(--outline-soft);
     }
 
     .options button.selected {
-        border-color: var(--accent);
-        box-shadow: 0 14px 26px var(--shadow-soft);
-        background: linear-gradient(135deg, var(--accent-soft), var(--surface-soft));
+        border-bottom-color: var(--outline-strong);
+        box-shadow: none;
     }
 
     .options button.correct {
-        border-color: color-mix(in srgb, var(--success) 80%, transparent);
-        background: linear-gradient(135deg, color-mix(in srgb, var(--success) 30%, transparent), var(--surface-soft));
+        border-bottom: 2px solid
+            color-mix(in srgb, var(--success) 85%, transparent);
+        background: color-mix(in srgb, var(--success) 12%, transparent);
+        box-shadow: 0 10px 18px color-mix(in srgb, var(--success) 16%, transparent);
+        border-radius: 12px;
     }
 
     .options button.incorrect {
-        border-color: color-mix(in srgb, var(--danger) 80%, transparent);
-        background: linear-gradient(135deg, color-mix(in srgb, var(--danger) 30%, transparent), var(--surface-soft));
+        border-bottom: 2px solid
+            color-mix(in srgb, var(--danger) 85%, transparent);
+        background: color-mix(in srgb, var(--danger) 12%, transparent);
+        box-shadow: none;
     }
 
     .bullet {
-        width: 32px;
-        height: 32px;
-        border-radius: 10px;
-        background: var(--surface-strong);
+        width: 26px;
+        height: 26px;
+        border-radius: 9px;
+        background: rgba(0, 0, 0, 0.18);
         display: grid;
         place-items: center;
         font-weight: 800;
-        color: var(--text);
-        border: 1px solid var(--outline-soft);
+        color: var(--ink-strong);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    .card.dark-mode .bullet {
+        background: rgba(255, 255, 255, 0.12);
+        color: #c8cede;
+        border: 1px solid rgba(255, 255, 255, 0.18);
     }
 
     .text {
-        color: var(--text);
+        color: var(--ink-strong);
         line-height: 1.4;
-        font-weight: 600;
+        font-weight: 700;
+    }
+
+    .card.dark-mode .text {
+        color: #c8cede;
     }
 
     .badge {
+        display: inline-flex;
+        justify-content: flex-end;
+        align-items: center;
+        width: 100%;
+        box-sizing: border-box;
         font-size: 0.8rem;
-        color: var(--success);
+        color: var(--text-subtle);
         font-weight: 800;
         letter-spacing: 0.04em;
+        text-align: center;
+        min-height: 1.6em;
+        padding: 0.18rem 0.4rem;
+        background: transparent;
+        border-radius: 6px;
+    }
+
+    .badge.placeholder {
+        visibility: hidden;
+        background: transparent;
+    }
+
+    .badge.correct-badge {
+        color: var(--success);
+        background: transparent;
     }
 
     .explanation {
-        padding: 0.95rem 1.05rem;
+        padding: 0.65rem 0.8rem;
         border-radius: 12px;
         border: 1px solid var(--outline-soft);
         background: var(--surface-soft);
         color: var(--text);
+        min-height: 110px;
+        transition: opacity 150ms ease;
+        opacity: 1;
+        display: grid;
+        gap: 0.35rem;
+    }
+
+    .explanation.placeholder {
+        opacity: 0;
+        pointer-events: none;
     }
 
     .explanation p {
@@ -389,7 +531,7 @@
         display: flex;
         justify-content: flex-end;
         gap: 0.75rem;
-        margin-top: 1.1rem;
+        margin-top: 1rem;
     }
 
     .actions button {
@@ -411,7 +553,11 @@
     }
 
     .actions .primary {
-        background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+        background: linear-gradient(
+            135deg,
+            var(--accent),
+            var(--accent-strong)
+        );
         color: var(--ink-strong);
         box-shadow: 0 10px 20px var(--shadow-soft);
     }
@@ -426,6 +572,9 @@
     }
 
     @media (max-width: 640px) {
+        .card {
+            min-height: 820px;
+        }
         .actions {
             flex-direction: column;
             align-items: stretch;

--- a/src/lib/components/VictoryOverlay/VictoryOverlay.svelte
+++ b/src/lib/components/VictoryOverlay/VictoryOverlay.svelte
@@ -3,11 +3,12 @@
     export let body: string;
     export let cta: string;
     export let onRestart: () => void;
+    export let theme: "light" | "dark" = "dark";
     export let imageSrc = "/illustrations/divine-mercy.png";
 </script>
 
-<div class="victory-overlay" role="dialog" aria-modal="true">
-    <div class="victory-card">
+<div class={`victory-overlay ${theme}`} role="dialog" aria-modal="true">
+    <div class={`victory-card ${theme}`}>
         <div class="victory-art">
             <img src={imageSrc} alt="Christ of Divine Mercy" loading="lazy" />
             <div class="cherub cherub-left">😇</div>
@@ -39,6 +40,17 @@
         animation: overlayFade 3000ms ease;
     }
 
+    .victory-overlay.light {
+        background:
+            radial-gradient(
+                circle at 40% 20%,
+                color-mix(in srgb, #f7ecd5 70%, var(--overlay-spot)),
+                color-mix(in srgb, #f0e2c8 70%, transparent)
+            ),
+            linear-gradient(180deg, rgba(248, 243, 231, 0.9), rgba(234, 215, 188, 0.85)),
+            var(--overlay-backdrop);
+    }
+
     .victory-card {
         display: grid;
         gap: 1rem;
@@ -51,6 +63,20 @@
         box-shadow: 0 24px 50px var(--shadow-strong);
         animation: cardFloat 680ms ease 120ms both;
         box-sizing: border-box;
+    }
+
+    .victory-card.light {
+        background:
+            linear-gradient(180deg, rgba(248, 243, 231, 0.92), rgba(234, 215, 188, 0.9)),
+            linear-gradient(160deg, var(--card-veil-1), var(--card-veil-2)),
+            var(--surface);
+        border-color: color-mix(in srgb, var(--accent-soft) 75%, #d9c9a5);
+        box-shadow: 0 20px 38px color-mix(in srgb, rgba(0, 0, 0, 0.3) 80%, transparent);
+    }
+
+    .victory-card.dark {
+        background: color-mix(in srgb, var(--surface) 90%, #0f1119);
+        border-color: var(--accent-soft);
     }
 
     .victory-art {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,8 @@ export type Question = {
     options: Option[];
     source?: string;
     image_url?: string;
+    image_url_light?: string;
+    image_url_dark?: string;
 };
 
 export type Level = { id: string; label: Record<Locale, string> };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -363,6 +363,7 @@
             body={t("perfectBody")}
             cta={t("perfectCTA")}
             onRestart={restart}
+            {theme}
         />
     {/if}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -93,6 +93,8 @@
         clearAnswerTimer();
         if (currentIndex >= questions.length - 1) {
             completed = true;
+        } else {
+            startAnswerTimer();
         }
     };
 
@@ -152,6 +154,7 @@
         revealed = false;
         clearAnswerTimer();
         timeLeft = ANSWER_TIMER_MS;
+        startAnswerTimer();
     };
 
     $: totalQuestions = questions.length;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -197,7 +197,13 @@
 
     const toggleTheme = () => applyTheme(theme === "dark" ? "light" : "dark");
 
+    let isMobile = false;
+
     onMount(() => {
+        const updateIsMobile = () => {
+            isMobile = typeof window !== "undefined" ? window.innerWidth <= 768 : false;
+        };
+        updateIsMobile();
         const stored =
             typeof localStorage !== "undefined"
                 ? localStorage.getItem("theme")
@@ -212,12 +218,14 @@
                   ? "dark"
                   : "light";
         applyTheme(next);
+        window.addEventListener("resize", updateIsMobile);
+        return () => window.removeEventListener("resize", updateIsMobile);
     });
 
     onDestroy(() => clearAnswerTimer());
 </script>
 
-<main class="page">
+<main class={`page ${theme === "light" ? "light-theme" : "dark-theme"}`}>
     <div class="glow gold" aria-hidden="true"></div>
     <div class="glow purple" aria-hidden="true"></div>
     <div class="glow crimson" aria-hidden="true"></div>
@@ -242,35 +250,40 @@
         {selectLanguage}
     />
 
-    <Hero
-        eyebrow={t("eyebrow")}
-        title={t("title")}
-        subtitle={t("subtitle")}
-        progressLabel={`${t("question")} ${started ? currentIndex + 1 : 0} ${t("of")} ${questions.length}`}
-        progressStage={started ? currentQuestion.stage[locale] : ""}
-        {progressPercent}
-    >
-        <MenuPanel
-            slot="panel"
-            title={t("profile")}
-            username={t("guestName")}
-            levelLabel={t("score")}
-            {levelValue}
-            accountLabel={t("account")}
-            loginLabel={t("login")}
-            guestPrefLabel={t("guestPref")}
-            styleLabel="Theme"
-            languageLabel={t("language")}
-            {languages}
-            {locale}
-            {flags}
-            {menuOpen}
-            {toggleMenu}
+    {#if !(started && isMobile)}
+        <Hero
+            eyebrow={t("eyebrow")}
+            title={t("title")}
+            subtitle={t("subtitle")}
+            progressLabel={`${t("question")} ${started ? currentIndex + 1 : 0} ${t("of")} ${questions.length}`}
+            progressStage={started
+                ? currentQuestion.stage[locale]
+                : questions[0]?.stage?.[locale] ?? ""}
+            {progressPercent}
             {theme}
-            {toggleTheme}
-            {selectLanguage}
-        />
-    </Hero>
+        >
+            <MenuPanel
+                slot="panel"
+                title={t("profile")}
+                username={t("guestName")}
+                levelLabel={t("score")}
+                {levelValue}
+                accountLabel={t("account")}
+                loginLabel={t("login")}
+                guestPrefLabel={t("guestPref")}
+                styleLabel="Theme"
+                languageLabel={t("language")}
+                {languages}
+                {locale}
+                {flags}
+                {menuOpen}
+                {toggleMenu}
+                {theme}
+                {toggleTheme}
+                {selectLanguage}
+            />
+        </Hero>
+    {/if}
 
     {#if started}
         {#key currentQuestion.id}
@@ -293,6 +306,7 @@
                 pauseTimer={pauseAnswerTimer}
                 resumeTimer={resumeAnswerTimer}
                 onHome={goHome}
+                {theme}
             />
         {/key}
     {:else}
@@ -327,6 +341,14 @@
         gap: 1.2rem;
         overflow: hidden;
         padding: 12px;
+    }
+
+    .page.light-theme {
+        background: linear-gradient(180deg, #f8f3e7 0%, #f2eadb 100%);
+    }
+
+    .page.dark-theme {
+        background: linear-gradient(180deg, #0f1119 0%, #131827 100%);
     }
 
     .glow {
@@ -364,27 +386,51 @@
         border: 1px solid var(--outline-soft);
         border-radius: 18px;
         background:
-            linear-gradient(
-                180deg,
-                var(--scene-overlay-1),
-                var(--scene-overlay-2)
-            ),
-            url("/illustrations/quest-hero.svg") center/cover,
+            linear-gradient(180deg, rgba(248, 243, 231, 0.9), rgba(234, 215, 188, 0.85)),
+            url("/illustrations/quest-hero-light.svg") center/cover,
             linear-gradient(160deg, var(--card-veil-1), var(--card-veil-2)),
             var(--bg);
         box-shadow: 0 18px 40px var(--shadow-strong);
         display: grid;
         gap: 1rem;
-        min-height: 360px;
+        min-height: 720px;
         align-content: space-between;
         justify-items: center;
+    }
+
+    .page.dark-theme .intro-card {
+        background:
+            linear-gradient(160deg, rgba(18, 26, 52, 0.9), rgba(18, 24, 41, 0.9)),
+            linear-gradient(160deg, rgba(12, 14, 24, 0.6), rgba(18, 20, 32, 0.6)),
+            url("/illustrations/quest-hero.svg") center/cover,
+            var(--bg);
+        color: var(--text);
+    }
+
+    .page.dark-theme .intro-eyebrow {
+        color: var(--accent);
+        text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+    }
+
+    .page.dark-theme .intro-body {
+        color: var(--text-muted);
+        text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+    }
+
+    .page.dark-theme .intro-card h2 {
+        color: var(--text);
+        text-shadow: 0 2px 10px rgba(0, 0, 0, 0.65);
+    }
+
+    .page.dark-theme .intro-note .link.disabled {
+        color: var(--text);
     }
 
     .intro-eyebrow {
         text-transform: uppercase;
         letter-spacing: 0.08em;
         font-weight: 800;
-        color: var(--text-subtle);
+        color: var(--accent);
         margin: 0;
     }
 
@@ -420,6 +466,13 @@
 
     .intro-note {
         margin: 0;
+    }
+
+    @media (max-width: 640px) {
+        .intro-card {
+            min-height: 820px;
+            padding: 1.8rem;
+        }
     }
 
     .intro-note .link {

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -16,6 +16,8 @@ const ensureLocales = (value: Record<string, string> | null | undefined) => {
 
 const mapQuestion = (raw: any, idx: number): Question => {
     const image_url = typeof raw?.image_url === "string" ? raw.image_url : undefined;
+    const image_url_light = typeof raw?.image_url_light === "string" ? raw.image_url_light : undefined;
+    const image_url_dark = typeof raw?.image_url_dark === "string" ? raw.image_url_dark : undefined;
 
     const options = Array.isArray(raw.options)
         ? raw.options.map((opt: any, i: number) => ({
@@ -33,13 +35,23 @@ const mapQuestion = (raw: any, idx: number): Question => {
             {} as Record<Locale, string>,
         );
 
+    const baseImage = image_url ?? "/illustrations/quest-hero.svg";
+    const lightImage =
+        image_url_light ??
+        (baseImage.includes("quest-hero")
+            ? "/illustrations/quest-hero-light.svg"
+            : baseImage);
+    const darkImage = image_url_dark ?? baseImage;
+
     return {
         id: raw?.id ?? `q-${idx}`,
         stage: ensureLocales(stageLabel),
         prompt: ensureLocales(raw?.prompt),
         options,
         source: raw?.source,
-        image_url: image_url ?? "/illustrations/quest-hero.svg",
+        image_url: baseImage,
+        image_url_light: lightImage,
+        image_url_dark: darkImage,
     };
 };
 

--- a/static/illustrations/quest-hero-light.svg
+++ b/static/illustrations/quest-hero-light.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Placeholder Biblical scene (light)</title>
+  <desc id="desc">Light-tinted version of the Verbum Quest hero scene with softened contrast.</desc>
+  <defs>
+    <linearGradient id="sky-light" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f7f1e3"/>
+      <stop offset="60%" stop-color="#e9dec6"/>
+      <stop offset="100%" stop-color="#d6c7ad"/>
+    </linearGradient>
+    <linearGradient id="sun-light" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#fbe2a3" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#e4bd6f" stop-opacity="0.85"/>
+    </linearGradient>
+    <linearGradient id="water-light" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#b7d4e6" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#8fbfda" stop-opacity="0.9"/>
+    </linearGradient>
+    <linearGradient id="hill-light" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#c5d1b4"/>
+      <stop offset="100%" stop-color="#a7b697"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="540" fill="url(#sky-light)"/>
+  <circle cx="160" cy="120" r="90" fill="url(#sun-light)" opacity="0.9"/>
+  <path d="M0 340 Q180 270 320 320 T640 310 T960 260 L960 540 L0 540 Z" fill="#d0d9c8" opacity="0.7"/>
+  <path d="M0 360 Q200 300 380 340 T720 320 T960 300 L960 540 L0 540 Z" fill="url(#hill-light)"/>
+  <path d="M0 410 C160 420 260 440 420 440 S720 410 960 440 L960 540 L0 540 Z" fill="url(#water-light)"/>
+  <path d="M520 260 L560 260 L540 160 Z" fill="#d8b06a" opacity="0.8"/>
+  <path d="M520 260 L540 190 L560 260 Z" fill="#e8c78a" opacity="0.8"/>
+  <rect x="620" y="210" width="10" height="95" fill="#c79d62"/>
+  <rect x="620" y="180" width="10" height="110" fill="#e8c78a"/>
+  <rect x="600" y="210" width="50" height="10" fill="#e8c78a"/>
+  <path d="M140 430 C200 400 300 400 360 430 S520 470 580 440 S760 390 860 430 L860 540 L140 540 Z" fill="#c8d5d4" opacity="0.55"/>
+  <circle cx="740" cy="120" r="22" fill="#f6d27f" opacity="0.65"/>
+  <circle cx="820" cy="90" r="14" fill="#f6d27f" opacity="0.55"/>
+  <circle cx="680" cy="80" r="12" fill="#f6d27f" opacity="0.5"/>
+</svg>

--- a/static/illustrations/quest-hero.svg
+++ b/static/illustrations/quest-hero.svg
@@ -27,13 +27,11 @@
   <path d="M0 410 C160 420 260 440 420 440 S720 410 960 440 L960 540 L0 540 Z" fill="url(#water)"/>
   <path d="M520 260 L560 260 L540 160 Z" fill="#d8a34b" opacity="0.8"/>
   <path d="M520 260 L540 190 L560 260 Z" fill="#e6c07a" opacity="0.8"/>
+  <rect x="620" y="210" width="10" height="95" fill="#c7943a"/>
   <rect x="620" y="180" width="10" height="110" fill="#f0c66a"/>
   <rect x="600" y="210" width="50" height="10" fill="#f0c66a"/>
-  <rect x="618" y="210" width="14" height="95" fill="#c7943a"/>
-  <rect x="620" y="220" width="10" height="70" fill="#0c1429" opacity="0.35"/>
   <path d="M140 430 C200 400 300 400 360 430 S520 470 580 440 S760 390 860 430 L860 540 L140 540 Z" fill="#0d1a33" opacity="0.6"/>
   <circle cx="740" cy="120" r="18" fill="#f0c66a" opacity="0.45"/>
   <circle cx="820" cy="90" r="10" fill="#f0c66a" opacity="0.35"/>
   <circle cx="680" cy="80" r="8" fill="#f0c66a" opacity="0.3"/>
-  <text x="720" y="500" font-family="DM Sans, Arial, sans-serif" font-size="16" fill="#e9edf4" opacity="0.7">Replace with final artwork</text>
 </svg>

--- a/static/illustrations/question-christ.svg
+++ b/static/illustrations/question-christ.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Light placeholder biblical scene</title>
+  <desc id="desc">A bright stylized landscape for Verbum Quest showing hills, water, sun rays, and a cross.</desc>
+  <defs>
+    <linearGradient id="sky-light" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f5efe0"/>
+      <stop offset="60%" stop-color="#e2d6bd"/>
+      <stop offset="100%" stop-color="#d4c6aa"/>
+    </linearGradient>
+    <linearGradient id="sun-light" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f9df9f" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#e4b967" stop-opacity="0.85"/>
+    </linearGradient>
+    <linearGradient id="water-light" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#a2c9dd" stop-opacity="0.8"/>
+      <stop offset="100%" stop-color="#7db2d0" stop-opacity="0.9"/>
+    </linearGradient>
+    <linearGradient id="hill-light" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#b8c5a9"/>
+      <stop offset="100%" stop-color="#9daf92"/>
+    </linearGradient>
+  </defs>
+  <rect width="960" height="540" fill="url(#sky-light)"/>
+  <ellipse cx="760" cy="120" rx="120" ry="90" fill="url(#sun-light)" opacity="0.9"/>
+  <path d="M0 320 Q160 260 320 300 T640 280 T960 320 L960 540 L0 540 Z" fill="url(#hill-light)"/>
+  <path d="M0 360 Q220 330 440 350 T960 360 L960 540 L0 540 Z" fill="#c9d7c0"/>
+  <path d="M0 390 Q200 410 400 395 T960 420 L960 540 L0 540 Z" fill="url(#water-light)"/>
+  <rect x="468" y="158" width="16" height="180" rx="2" fill="#9b7d4d"/>
+  <rect x="420" y="210" width="112" height="16" rx="2" fill="#9b7d4d"/>
+  <path d="M0 180 Q120 150 240 180 T480 190 T720 170 T960 190 L960 320 L0 320 Z" fill="rgba(255,255,255,0.38)"/>
+</svg>


### PR DESCRIPTION
-  Add per-question retake flow (one retry, “Retake” button replaces “Restart,” never reveal correct on misses; disable retake after use).
- Add custom confirmation modal for Home action; reset progress only on confirm.
- Improve badges (check/X), question styles, and mobile stability; adjust overlay/dialog sizing and theme-aligned visuals.
- Theme-aware Victory overlay with gold-tinted light mode styling